### PR TITLE
Update nginx image to 1.28.0-alpine

### DIFF
--- a/simple-nginx/deployment.yaml
+++ b/simple-nginx/deployment.yaml
@@ -13,7 +13,7 @@ spec:
         app: nginx # Label applied to the Pods
     spec:
       containers:
-      - name: nginx
-        image: nginx:alpine # Use a lightweight Nginx image
-        ports:
-        - containerPort: 80 # Nginx listens on port 80
+        - name: nginx
+          image: nginx:1.28.0-alpine # Use a lightweight Nginx image
+          ports:
+            - containerPort: 80 # Nginx listens on port 80


### PR DESCRIPTION
Automated image update for container `nginx`.
New tag: `1.28.0-alpine`
Manifest file: `simple-nginx/deployment.yaml`

This PR was created automatically by the "Update Image Tag" GitHub Action.